### PR TITLE
Add name key to fermi_hgps_data_config.yaml

### DIFF
--- a/fermi-hgps/fermi_hgps_data_config.yaml
+++ b/fermi-hgps/fermi_hgps_data_config.yaml
@@ -1,5 +1,7 @@
 # Fermi dataset entry file
 # The file has to be kept in sync with fermi_hgps_data_prepare.sh
+name : Fermi-HGPS
+
 filenames:
   events    : fermi_hgps_events.fits.gz
   exposure  : fermi_hgps_exposure_hpx.fits.gz


### PR DESCRIPTION
When working with the Fermi HGPS dataset I got

```
KeyError: 'name'  
```

I am not sure exactly where (some print function I think). This should fix it.